### PR TITLE
wolff in field using ghost spin, and fixed bug in reset_measurements()

### DIFF
--- a/ising.js
+++ b/ising.js
@@ -349,7 +349,7 @@ function download_measurements(){
         csv += gtimeseries_energy[i]+", ";
         csv += gtimeseries_mag[i]+"\n";
     }
-    var encoded = encodeURI(csv);
+    var encoded = encodeURI(csv).replace(/#/g,'%23');
     hidden_link_download(encoded, 'ising-data.txt');
 }
 


### PR DESCRIPTION
changed update_wolff to use a ghost spin (site gN * gN in the array) for simulations of a field

fixed reset_measurements, which used to take the sum of bond energies (which includes a double-counting) and the sum of field energies (which doesn't) and divided _both_ by two, and now divides only the sum of bond energies by two